### PR TITLE
Add option to specify units and therefore use Celcius if desired.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,4 +78,16 @@ Device ID: KoTA9-raY9xdYrYY036u2rgaeP_lJ-mg
 Structure ID: Suha_CVEVHdOreQFLWC-XlHaPXSRHcEwOb8dKkwYIjcVN0XCBSnKLQ
 ```
 
+# Configuration keys
+accesstoken = "ACCESSTOKEN"
 
+mythermostat = "MYDEVICEID"
+
+units = "[cCfF]"
+
+# Choosing units for temperature
+By default nerdnest uses Farenheit for temperature both to display the status and when setting temperature. You can
+override this behavior by adding a configuration key called units and setting it to either "c" or "C".
+
+For Farenheit you must specify the temperature in whole numbers e.g. 70, 75
+For Celcius you can specify half units as well e.g. 19, 20.5, 23.5


### PR DESCRIPTION
I have added the option to specify units and therefore use Celcius if desired. Retains default of Farenheit and doesn't break existing behavior (all command syntax is the same and if the extra config option isn't present it just works as before using Farenheit)

I have also updated the Readme to describe the configuration keys available, including the new one and added a section describing this new feature